### PR TITLE
Adding 16bit isize/usize support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "intbits"
 description = "Easy access to individual bits of integers"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Mara Bos <m-ou.se@m-ou.se>"]
 license = "BSD-2-Clause"
 edition = "2018"

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -158,6 +158,12 @@ bits!(u64, u64, 63);
 bits!(i128, u128, 127);
 bits!(u128, u128, 127);
 
+#[cfg(target_pointer_width = "16")]
+bits!(isize, usize, 15);
+
+#[cfg(target_pointer_width = "16")]
+bits!(usize, usize, 15);
+
 #[cfg(target_pointer_width = "32")]
 bits!(isize, usize, 31);
 


### PR DESCRIPTION
Adding 16-bit isize/usize, to support Microchip/Atmel AVR and probably some other embedded micro-controllers.

> Code is not tested, neither any extra doc is added, Version is bumped

@m-ou-se 